### PR TITLE
Changed message types enum 'Reaction' to the right value

### DIFF
--- a/packages/meta-cloud-api/src/types/enums.ts
+++ b/packages/meta-cloud-api/src/types/enums.ts
@@ -24,7 +24,7 @@ export enum MessageTypesEnum {
     Image = 'image',
     Interactive = 'interactive',
     Location = 'location',
-    Reaction = 'sticker',
+    Reaction = 'reaction',
     Sticker = 'sticker',
     Template = 'template',
     Text = 'text',


### PR DESCRIPTION
## Changes
The list of MessageTypeEnums had the key-value pair `Reaction = 'sticker'` which is incorrect. Sticker type was already there and "Reaction" should have the value `reaction`.
