### PR TITLE
Context from- and id property to WebhookMessage object

### DIFF
--- a/packages/meta-cloud-api/src/types/webhook.ts
+++ b/packages/meta-cloud-api/src/types/webhook.ts
@@ -352,6 +352,14 @@ export interface WebhookMessage {
      */
     context?: {
         /**
+         * ID of the message
+         */
+        id?: string;
+        /**
+         * ID of the sender
+         */
+        from?: string;
+        /**
          * ID of the message being replied to or interacted with
          */
         message_id: string;


### PR DESCRIPTION
## Changes
In case of an incoming reply, the context object will include a from- and id property that refers to the original message id. Added those properties to the WebhookMessage interface.