### PR TITLE
docs: apply July 2026 Cloud API changelog entries (#419, #420)

### DIFF
--- a/CLOUD_API_CHANGELOG.md
+++ b/CLOUD_API_CHANGELOG.md
@@ -1,8 +1,16 @@
 # WhatsApp Business Platform API — Changelog Tracker
 
 > Source: https://developers.facebook.com/documentation/business-messaging/whatsapp/changelog
-> Updated: 2026-06-09T06:43:10.860Z
+> Updated: 2026-07-27T00:00:00.000Z
 
+
+## July 20, 2026
+
+- [x] **#420** Added instructions for requesting a review of a Direct Send template flagged as marketing.
+
+## July 15, 2026
+
+- [x] **#419** Added the Phone Number First flow to a subset of business customers in the default Embedded Signup flow.
 
 ## July 3, 2026
 
@@ -1067,4 +1075,4 @@
 
 ---
 
-**Progress: 419/419 (100%)**
+**Progress: 421/421 (100%)**


### PR DESCRIPTION
## Summary

Applies the two new Cloud API changelog entries surfaced by the automated tracker in #58.

| ID | Date | Summary | Impact |
| --- | --- | --- | --- |
| #419 | Jul 15, 2026 | Phone Number First flow added to a subset of business customers in the default Embedded Signup flow | Docs-only |
| #420 | Jul 20, 2026 | Instructions for requesting review of a Direct Send template flagged as marketing | Docs-only |

## Why no code change

Both entries are UI/process changes with no server-side SDK contract impact:

- **#419** — Embedded Signup is a Meta-hosted frontend flow (the JS SDK signup wizard). "Phone Number First" is a variation of that hosted UI, not an API endpoint, payload, or webhook change. This server-side TypeScript SDK has no Embedded Signup surface.
- **#420** — Requesting a marketing-flag review for a Direct Send template is a manual process through WhatsApp Manager, not an API operation.

This follows the same pattern used for prior docs-only entries (#412, #414, #418): tracker updated and checked off with no code impact. No changeset is added because the published package is unchanged.

## Changes

- `CLOUD_API_CHANGELOG.md`: add #419 and #420 as checked entries, bump progress to 421/421, refresh the `Updated` timestamp.

Closes #58.